### PR TITLE
Chunking for CSV Import enabling larger CSV files

### DIFF
--- a/src/components/CsvImport/csv.js
+++ b/src/components/CsvImport/csv.js
@@ -6,8 +6,6 @@ const hintsByCode = {
   TooManyFields: 'Edit your CSV or try another delimiter.'
 }
 
-let parsedData = {}
-
 export default {
   getResult (source) {
     const result = {}
@@ -30,6 +28,7 @@ export default {
   },
 
   parse (file, config = {}) {
+    let parsedData = {}
     return new Promise((resolve, reject) => {
       const defaultConfig = {
         delimiter: '', // auto-detect
@@ -48,12 +47,12 @@ export default {
           if (Object.keys(parsedData).length === 0 && parsedData.constructor === Object) {
             parsedData = results
           } else {
-            parsedData.data = [...parsedData.data, ...results.data]
-            parsedData.errors = [...parsedData.errors, ...results.errors]
+            parsedData.data = parsedData.data.concat(results.data)
+            parsedData.errors = parsedData.errors.concat(results.errors)
           }
         },
-        chunkSize: 1024 * 1024 * 10,
-        complete: results => {
+        chunkSize: 1024 * 716,
+        complete: () => {
           const res = {
             data: this.getResult(parsedData),
             delimiter: parsedData.meta.delimiter,

--- a/src/components/CsvImport/csv.js
+++ b/src/components/CsvImport/csv.js
@@ -44,10 +44,19 @@ export default {
         worker: true,
         comments: false,
         step: undefined,
+        chunk: results => {
+          if (Object.keys(parsedData).length === 0 && parsedData.constructor === Object) {
+            parsedData = results
+          } else {
+            parsedData.data = [...parsedData.data, ...results.data]
+            parsedData.errors = [...parsedData.errors, ...results.errors]
+          }
+        },
+        chunkSize: 1024 * 1024 * 10,
         complete: results => {
           const res = {
             data: this.getResult(parsedData),
-            delimiter: results.meta.delimiter,
+            delimiter: parsedData.meta.delimiter,
             hasErrors: false
           }
           res.messages = parsedData.errors.map(msg => {
@@ -65,15 +74,6 @@ export default {
         downloadRequestHeaders: undefined,
         downloadRequestBody: undefined,
         skipEmptyLines: 'greedy',
-        chunk: results => {
-          if (Object.keys(parsedData).length === 0 && parsedData.constructor === Object) {
-            parsedData = results
-          } else {
-            parsedData.data = [...parsedData.data, ...results.data]
-            parsedData.errors = [...parsedData.errors, ...results.errors]
-          }
-        },
-        chunkSize: 1024 * 1024 * 10,
         fastMode: undefined,
         beforeFirstChunk: undefined,
         withCredentials: undefined,

--- a/src/components/CsvImport/csv.js
+++ b/src/components/CsvImport/csv.js
@@ -6,6 +6,8 @@ const hintsByCode = {
   TooManyFields: 'Edit your CSV or try another delimiter.'
 }
 
+let parsedData = {}
+
 export default {
   getResult (source) {
     const result = {}
@@ -44,11 +46,11 @@ export default {
         step: undefined,
         complete: results => {
           const res = {
-            data: this.getResult(results),
+            data: this.getResult(parsedData),
             delimiter: results.meta.delimiter,
             hasErrors: false
           }
-          res.messages = results.errors.map(msg => {
+          res.messages = parsedData.errors.map(msg => {
             msg.type = msg.code === 'UndetectableDelimiter' ? 'info' : 'error'
             if (msg.type === 'error') res.hasErrors = true
             msg.hint = hintsByCode[msg.code]
@@ -63,8 +65,15 @@ export default {
         downloadRequestHeaders: undefined,
         downloadRequestBody: undefined,
         skipEmptyLines: 'greedy',
-        chunk: undefined,
-        chunkSize: undefined,
+        chunk: results => {
+          if (Object.keys(parsedData).length === 0 && parsedData.constructor === Object) {
+            parsedData = results
+          } else {
+            parsedData.data = [...parsedData.data, ...results.data]
+            parsedData.errors = [...parsedData.errors, ...results.errors]
+          }
+        },
+        chunkSize: 1024 * 1024 * 10,        
         fastMode: undefined,
         beforeFirstChunk: undefined,
         withCredentials: undefined,

--- a/src/components/CsvImport/csv.js
+++ b/src/components/CsvImport/csv.js
@@ -73,7 +73,7 @@ export default {
             parsedData.errors = [...parsedData.errors, ...results.errors]
           }
         },
-        chunkSize: 1024 * 1024 * 10,        
+        chunkSize: 1024 * 1024 * 10,
         fastMode: undefined,
         beforeFirstChunk: undefined,
         withCredentials: undefined,

--- a/src/components/CsvImport/csv.js
+++ b/src/components/CsvImport/csv.js
@@ -28,7 +28,7 @@ export default {
   },
 
   parse (file, config = {}) {
-    let parsedData = {}
+    let parsedData = null
     return new Promise((resolve, reject) => {
       const defaultConfig = {
         delimiter: '', // auto-detect
@@ -44,7 +44,7 @@ export default {
         comments: false,
         step: undefined,
         chunk: results => {
-          if (Object.keys(parsedData).length === 0 && parsedData.constructor === Object) {
+          if (parsedData === null) {
             parsedData = results
           } else {
             parsedData.data = parsedData.data.concat(results.data)


### PR DESCRIPTION
This request enables chunking of the CSV data and allows you to import larger CSVs. The parsedData is still stored in memory and likely should be refactored to importing on each chunk. Importing on each chunk would require a greater refactor. 